### PR TITLE
WIP Support for on_schema_change configuration

### DIFF
--- a/core/dbt/adapters/base/impl.py
+++ b/core/dbt/adapters/base/impl.py
@@ -478,6 +478,15 @@ class BaseAdapter(object):
         )
 
     @abc.abstractmethod
+    def has_schema_changed(self, goal, current):
+        """ This can be sepearater methods for each way the scheam can differ, but
+        for right now just combine them as a default
+        """
+        raise dbt.exceptions.NotImplementedException(
+                '`has_schema_changed` is not implemented for this adapter!'
+        )
+
+    @abc.abstractmethod
     def list_relations_without_caching(self, information_schema, schema):
         """List relations in the given schema, bypassing the cache.
 
@@ -592,6 +601,24 @@ class BaseAdapter(object):
             quote_policy=self.config.quoting
         )
         self.expand_column_types(goal, to_relation)
+
+    @available
+    def target_contains_schema_change(self, old_relation, to_relation):
+        if not isinstance(to_relation, self.Relation):
+            dbt.exceptions.invalid_type_error(
+                method_name='target_contains_schema_change',
+                arg_name='to_relation',
+                got_value=to_relation,
+                expected_type=self.Relation)
+
+        if not isinstance(old_relation, self.Relation):
+            dbt.exceptions.invalid_type_error(
+                method_name='target_contains_schema_change',
+                arg_name='old_relation',
+                got_value=old_relation,
+                expected_type=self.Relation)
+
+        return self.has_schema_changed(old_relation, to_relation)
 
     def list_relations(self, database, schema):
         if self._schema_is_cached(database, schema):

--- a/core/dbt/adapters/sql/impl.py
+++ b/core/dbt/adapters/sql/impl.py
@@ -104,6 +104,59 @@ class SQLAdapter(BaseAdapter):
 
                 self.alter_column_type(current, column_name, new_type)
 
+    def has_schema_changed(self, goal, current):
+        """
+        Look for schema changes between the target columns and reference columns
+        Step through each column and return that a schema change *has* happened
+        if any of the following are true:
+        1. Number of columns are different (column has been added or removed)
+        2. Columns have different names
+        3. Columns have different data type
+        4. Columns have different data type size
+        """
+        reference_columns = {
+            c.name: c for c in
+            self.get_columns_in_relation(goal)
+        }
+
+        # Theoretically this works, but postgres temporary tables are held within their
+        # own schema, so it's not possible to track the differences.
+        # This logic should work with Snowflake based on manual testing, but not confirmed
+        # in this code path.
+        target_columns = {
+            c.name: c for c in
+            self.get_columns_in_relation(current)
+        }
+
+        # 1. The schema has changed if columns have been added or removed
+        if len(reference_columns) != len(target_columns):
+            logger.debug("Schema difference detected: Reason 1")
+            return True
+
+        for reference_column_name, reference_column in reference_columns.items():
+            target_column = target_columns.get(reference_column_name)
+            # 2a. The schema has changed if a reference column is not found in the target columns
+            if target_column is None:
+                logger.debug("Schema difference detected: Reason 2a")
+                return True
+
+            # 3/4. If the columns do not have the same data type and size (see core/dbt/schema.py for more details)
+            if reference_column.data_type != target_column.data_type:
+                logger.debug("Schema difference detected: Reason 3/4")
+                return True
+
+        for i, target_column_name in enumerate(target_columns):
+            reference_column = reference_columns.get(target_column_name)
+            target_column = target_columns.get(target_column_name)
+            # 2b. The schema has changed if a target column is not found in the reference columns
+            if reference_column is None:
+                logger.debug("Schema difference detected: Reason 2b")
+                return True
+
+        # Nothing has detected as changed
+        logger.debug("No schema difference detected")
+        return False
+
     def alter_column_type(self, relation, column_name, new_column_type):
         """
         1. Create a new column (w/ temp name and correct type)

--- a/core/dbt/contracts/graph/parsed.py
+++ b/core/dbt/contracts/graph/parsed.py
@@ -80,6 +80,9 @@ CONFIG_CONTRACT = {
                 }
             ]
         },
+        'on_schema_change': {
+            'type': 'string'
+        }
     },
     'required': [
         'enabled', 'materialized', 'post-hook', 'pre-hook', 'vars',

--- a/core/dbt/exceptions.py
+++ b/core/dbt/exceptions.py
@@ -243,6 +243,10 @@ class FailedToConnectException(DatabaseException):
     pass
 
 
+class SchemaChangeException(RuntimeException):
+    CODE=1008
+
+
 class CommandError(RuntimeException):
     def __init__(self, cwd, cmd, message='Error running command'):
         super(CommandError, self).__init__(message)
@@ -651,6 +655,10 @@ def raise_unrecognized_credentials_type(typename, supported_types):
 def raise_not_implemented(msg):
     raise NotImplementedException(msg)
 
+def raise_fail_on_schema_change():
+    MESSAGE="Schema change detected and configuration of on_schema_change set to 'fail'"
+    raise SchemaChangeException(MESSAGE)
+
 
 def warn_or_error(msg, node=None, log_fmt=None):
     if dbt.flags.WARN_ERROR:
@@ -681,6 +689,7 @@ CONTEXT_EXPORTS = {
         raise_duplicate_resource_name,
         raise_invalid_schema_yml_version,
         relation_wrong_type,
+        raise_fail_on_schema_change,
     ]
 }
 

--- a/core/dbt/version.py
+++ b/core/dbt/version.py
@@ -56,5 +56,5 @@ def get_version_information():
                 .format(version_msg))
 
 
-__version__ = '0.13.0'
+__version__ = '0.13.20190426'
 installed = get_installed_version()


### PR DESCRIPTION
# Goal

This is a work in progress Pull Request for the implementation of the following feature for DBT: https://github.com/fishtown-analytics/dbt/issues/1132

The specific aspect of the feature that we want is for DBT tasks to error out with a specific message/error code when a schema change is detected in the model.

# Approach

The general approach I took for implementing the "fail on schema change" feature is to:
1. Add a new configuration key `on_schema_change` to the appropriate contract - `core/dbt/contracts/graph/parsed.py`
2. Create a new SchemaChangeException that will be thrown when a schema change is detected and should be failed - `core/dbt/exceptions.py`
3. Add a new abstract method to hold the logic for detecting a schema change for each type of DB - `core/dbt/adapters/base/impl.py`
4. Add a concrete implementation for the sql adapter - `core/dbt/adapters/sql/impl.py`
  - There may be a better way to do this to make the logic more user configurable. Perhaps by splitting this into multiple methods that test each schema change condition?
5. When performing an incremental materialization, get the config to see if fail on schema change is set, and then call the adapter to see if the schema has been changed. If both are true, raise our SchemaChangedException
  - Similar to the last step, there may be an implementation that allows users to override this functionality with their own macro, but I'm not sure the best way the DBT team would want that implemented.
6. [WIP] Integration tests for multiple configuration setups
7. [Not started] Working unit tests and style cleaned up

## Temporary Tables

Temporary tables in Postgres are created in their own schema, so the tables are not found through the normal queries against the Postgres information schema. Since I was testing locally with Postgres, I was unable to confirm the all the different schema change use cases.

Temporary tables in Snowflake are created within the same schema, so I did some manual testing against the Snowflake console. Running the following test queries in the Snowflake console created a temporary table and then successfully listed the columns on that table, which gives me confidence that the integration test will work if migrated to Snowflake. The second query is taken from the get_columns_in_relation macro in the `plugins/snowflake/macros/adapters.sql` file.

```sql
create temporary table "CONVOY"."USR"."mgolazeski_temporary_test" (id bigint, test_col_1 double, test_col_2 string);
```

```sql
select
    column_name,
    data_type,
    character_maximum_length,
    numeric_precision,
    numeric_scale

from
  information_schema.columns

where table_name ilike 'mgolazeski_temporary_test'
  and table_schema ilike 'USR'
  and table_catalog ilike 'CONVOY'
order by ordinal_position;
```

# Developing DBT Locally

## Example DBT project

Example DBT task locally:

The following repro is a small DBT project set up by the makers of DBT. This is an easy way to test the dbt run command while developing, and the README for the package walks through the basic DBT use cases nicely for beginners. I updated the seed.csv & moby_dick_base.sql with more columns and overwrote the word_count project model to materialize incrementally and to fail on any schema change:

github.com/fishtown-analytics/talk.git

```
{{
  config(
    materialized='incremental',
    on_schema_change='fail'
  )
}}
```

The actual command for running against just that model is

```
dbt run --model=word_count
```

Setting up pyenv and pyenv-virtualenv allows you to share your in-development DBT executable with the example talk project without any kind of need to copy binaries or repackage DBT. These commands (run within the talk environment), match up the same pyenv environment:

In local DBT directory:

```
$ pyenv install 3.6.5
$ pyenv virtual env 3.6.5 local-dbt-3.6.5
$ pyenv local local-dbt-3.6.5
$ pyenv activate
```

In talk project directory:
```
$ pyenv local local-dbt-3.6.5
$ pyenv activate
```

Now, any changes you make in your local DBT development directory will take effect when you run a DBT command from the talk project directory. An easy test can be changing the version of DBT located in `core/dbt/version.py`

```
talk $ dbt --version
installed version: 0.13.20190426
   latest version: 0.13.0

Your version of dbt is ahead of the latest release!
```

## Speed up integration tests by specifying which test to run

You can run the integration tests faster by modifying the tox.ini for a specific command that gets kicked off by ```make test-integration``` and running the following.

```
docker-compose run test tox -e integration-postgres-py36
```

For example, by changing the tox.ini under the [testenv:integration-postgres-py36] heading to something like the following, a single integration test will be run without any code coverage, greatly speeding up the runtime while testing.

```
commands = /bin/bash -c '{envpython} $(which nosetests) -v -a type=postgres  {posargs} test/integration/044_on_schema_change_test/*'
```

## Adding additional logging for local debugging
### Logging in DBT python code:

Use ```logger.debug("var value: {}".format(var))```
If the logger does not exist in the file, you can add `from dbt.logger import GLOBAL_LOGGER as logger` to get access to it
If there are crashes because the logger is not initialized yet you can move the following code from its original spot in core/dbt/main.py to be the first line in the main method ```initialize_logger(False, 'logs')```

### Logging in DBT templated SQL code:
Use ```{{ log("val value" ~ val) }}```
If you concat something that is not a string, you will get jinja compilation errors, but you are able to cheat by using python's str or repr method (there may be more efficient ways)
```{{ log("obj string value" ~ str(obj)) }}```

## Using a debugger
Anywhere in the DBT code, you can add the following to break to an interactive debugger to examine the current state of the runtime.

Full details here: https://docs.python.org/3/library/pdb.html

Tracing the creation of the result object when there is an exception
